### PR TITLE
Exclude unnecessary files from package

### DIFF
--- a/EngageJackrabbit.Build
+++ b/EngageJackrabbit.Build
@@ -286,6 +286,7 @@
     <include name="MSBuild/*.targets"/>
     <include name="CustomDictionary.xml"/>
     <exclude name="**/obj/**"/>
+    <exclude name="**/bin/**"/>
     <exclude name="Release.txt" />
   </patternset>
 </project>


### PR DESCRIPTION
Excluding 'bin' folder and 'CustomDictionary.xml' from Resources.zip in the install package.
